### PR TITLE
add list.inactiveSelectionBackground

### DIFF
--- a/themes/ZhaiSasi-color-theme.json
+++ b/themes/ZhaiSasi-color-theme.json
@@ -213,6 +213,8 @@
         "tab.activeForeground": "#000", //当前标签字体颜色
         "tab.hoverBackground": "#C0CCD3", //鼠标悬浮的标签背景颜色
         "minimap.findMatchHighlight":"#789",//迷你地图匹配的内容背景色
+        "list.inactiveSelectionBackground": "#219fd5cc", // 侧边栏文件列表未激活背景色
+        "list.inactiveSelectionForeground": "#345", // 侧边栏文件列表未激活前景色
     },
     "name": "ZhaiSasi"
 }


### PR DESCRIPTION
不错的主题。
由于该主题的`"sideBar.background"`是`#E1E5EA`,
而 vscode 的默认`list.inactiveSelectionBackground`是`#E4E6F1`，（参考:[vscode/src/vs/platform/theme/common/colorRegistry.ts#L353](https://github.com/microsoft/vscode/blob/ba33738bb3db01e37e3addcdf776c5a68d64671c/src/vs/platform/theme/common/colorRegistry.ts#L353))。
`#E1E5EA`和`#E4E6F1`是比较相近的颜色，因此当处于 inactive 状态时很难区分它们。
将`list.inactiveSelectionBackground`换成比较容易区分的颜色体验会更好。
这个 PR 将`list.inactiveSelectionBackground`设置为`#219fd5cc`，偏蓝色，作者可以根据自己喜好调整。
`list.inactiveSelectionForeground`设置为`#345`，即`sideBar.foreground`的颜色。
